### PR TITLE
Add `jitpack.yml` to ensure JitPack uses Java 16

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ loader_version=0.11.6
 fabric_version=0.36.0+1.17
 
 # Mod Properties
-mod_version = 4.2.2
+mod_version = 4.2.3
 maven_group = mc.rpgstats
 archives_base_name = rpgstats
 

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+before_install:
+  - wget https://github.com/sormuras/bach/raw/master/install-jdk.sh
+  - source install-jdk.sh --feature 16


### PR DESCRIPTION
Due to now requiring Java 16, this project won't build on JitPack. This fixes it according to a solution posed n the Fabric Discord. A new release with this change would also be required, but that isn't within the scope of a pull request.